### PR TITLE
Photon field unified sampling

### DIFF
--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -176,6 +176,8 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 	double epsMin = 0.;
 	double epsMax = 0.;
 
+	// get epsMin and epsMax for both cases
+	// TODO: use the min and max values from the tabulated files
 	if (bgFlag == 1) {
 		// CMB
 		const double tbb = 2.73 * (1. + z_in);
@@ -186,7 +188,6 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			return 0.;
 		}
 	}
-
 	if (bgFlag == 2) {
 		// IRB_Kneiske04     
 		epsMin = std::max(0.00395, 1.e9 * (1.1646 - mass * mass) / 2. / (E_in + P_in));  // eV
@@ -197,11 +198,12 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 		}
 	}
 
+	// find pMax for current interaction to have a reference for the MC rejection
+	// TODO: should loop through the tabulated table instead
 	const int i_max = static_cast<int>(10. * std::log(epsMax / epsMin)) + 1;
 	const double de = std::log(epsMax / epsMin) / i_max;
 	double eps_dum = 0.;
 	double pMax = 0.;
-
 	for (int i = 0; i < i_max; ++i) {
 		eps_dum = epsMin * std::exp(i * de);
 		const double prob = this->prob_eps(eps_dum, onProton, E_in, z_in);

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -208,14 +208,13 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 		}
 		const int i_max = static_cast<int>(10. * std::log(epsMax / epsMin)) + 1;
 		const double de = std::log(epsMax / epsMin) / i_max;
-		double rmax = 0.;
 		double eps_dum = 0.;
-		double dum = 0.;
+		double pMax = 0.;
 		for (int i = 0; i < i_max; ++i) {
 			eps_dum = epsMin * std::exp(i * de);
-			dum = getPhotonDensity(eps_dum, z_in);
-			if (dum > rmax)
-				rmax = dum;
+			const double prob = this->prob_eps(eps_dum, onProton, E_in, z_in);
+			if (prob > pMax)
+				pMax = prob;
 		}
 		const double beta = 4.;
 		const double e1 = std::pow(epsMin, 1. - beta);
@@ -233,7 +232,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			eps = std::pow(random.rand() * (e1 - e2) + e2, 1./(1. - beta));
 			i_rep++;
 			peps = prob_eps(eps, onProton, E_in, z_in);
-			if (random.rand() < getPhotonDensity(eps, z_in) / rmax)
+			if (random.rand() * pMax < peps)
 				keepTrying = false;
 		} while (keepTrying);
 	}

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -207,6 +207,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			std::cout << "sample_eps (IRB): CMF energy is below threshold for nucleon energy " << E_in << " GeV !" << std::endl;
 			return 0.;
 		}
+		const double cnorm = gaussInt([this, onProton, E_in, z_in](double e) { return this->prob_eps(e, onProton, E_in, z_in); }, epsMin, epsMax);
 		const int i_max = static_cast<int>(10. * std::log(epsMax / epsMin)) + 1;
 		const double de = std::log(epsMax / epsMin) / i_max;
 		double rmax = 0.;
@@ -224,6 +225,8 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 		bool keepTrying = true;
 		int i_rep = 0;
 		Random &random = Random::instance();
+		// sample eps between epsMin ... epsMax
+		double peps = 0.;
 		do {
 			if (i_rep >= 100000) {
 				keepTrying = false;
@@ -231,6 +234,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			}
 			eps = std::pow(random.rand() * (e1 - e2) + e2, 1./(1. - beta));
 			i_rep++;
+			peps = prob_eps(eps, onProton, E_in, z_in) / cnorm;
 			if (random.rand() < getPhotonDensity(eps, z_in) / rmax)
 				keepTrying = false;
 		} while (keepTrying);

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -183,10 +183,9 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			return 0.;
 		}
 
-		const double cnorm = gaussInt([this, onProton, E_in, z_in](double e) { return this->prob_eps(e, onProton, E_in, z_in); }, epsMin, epsMax);
 		const double epskt = 8.619e-5 * tbb;
 		const double epspmax = (3.e-3 * std::pow(E_in * epskt * 1.e-9, -0.97) + 0.047) / 3.9e2 * tbb;
-		const double pmaxc = prob_eps(epspmax, onProton, E_in, z_in) / cnorm;
+		const double pmaxc = prob_eps(epspmax, onProton, E_in, z_in);
 		const double facpmax = 1.6;
 		const double pMax = facpmax * pmaxc;
 
@@ -195,7 +194,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 		Random &random = Random::instance();
 		do {
 			eps = epsMin + random.rand() * (epsMax - epsMin);
-			peps = prob_eps(eps, onProton, E_in, z_in) / cnorm;
+			peps = prob_eps(eps, onProton, E_in, z_in);
 		} while (random.rand() * pMax > peps);
 	}
 
@@ -207,7 +206,6 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			std::cout << "sample_eps (IRB): CMF energy is below threshold for nucleon energy " << E_in << " GeV !" << std::endl;
 			return 0.;
 		}
-		const double cnorm = gaussInt([this, onProton, E_in, z_in](double e) { return this->prob_eps(e, onProton, E_in, z_in); }, epsMin, epsMax);
 		const int i_max = static_cast<int>(10. * std::log(epsMax / epsMin)) + 1;
 		const double de = std::log(epsMax / epsMin) / i_max;
 		double rmax = 0.;
@@ -234,7 +232,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			}
 			eps = std::pow(random.rand() * (e1 - e2) + e2, 1./(1. - beta));
 			i_rep++;
-			peps = prob_eps(eps, onProton, E_in, z_in) / cnorm;
+			peps = prob_eps(eps, onProton, E_in, z_in);
 			if (random.rand() < getPhotonDensity(eps, z_in) / rmax)
 				keepTrying = false;
 		} while (keepTrying);

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -214,7 +214,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 		double dum = 0.;
 		for (int i = 0; i < i_max; ++i) {
 			eps_dum = epsMin * std::exp(i * de);
-			dum = eps_dum * eps_dum * getPhotonDensity(eps_dum, z_in);
+			dum = getPhotonDensity(eps_dum, z_in);
 			if (dum > rmax)
 				rmax = dum;
 		}
@@ -231,7 +231,7 @@ double PhotonFieldSampling::sample_eps(bool onProton, double E_in, double z_in) 
 			}
 			eps = std::pow(random.rand() * (e1 - e2) + e2, 1./(1. - beta));
 			i_rep++;
-			if (random.rand() < eps * eps * getPhotonDensity(eps, z_in) / rmax)
+			if (random.rand() < getPhotonDensity(eps, z_in) / rmax)
 				keepTrying = false;
 		} while (keepTrying);
 	}


### PR DESCRIPTION
First step to unify the sampling routine. IRB and CMB use the same for loop to find the photon in the interaction.

Also, removed the computation of cnorm for performance improvement.